### PR TITLE
Update RubyClientCodegen to support modelPropertyNaming

### DIFF
--- a/TEMPLATE_CHANGES.MD
+++ b/TEMPLATE_CHANGES.MD
@@ -13,6 +13,7 @@
 - Fix module description (the Ruby gem for the {{appName}} API)
 - Add config.host code sample
 - Add Smooch API version table
+- Add modelPropertyNaming support
 
 
 ### modules/swagger-codegen/src/main/resources/ruby/api_doc.mustache


### PR DESCRIPTION
Updated RubyClientCodegen to support modelPropertyNaming.

[Trello card](https://trello.com/c/VBAAbx95/8211-smooch-ruby-message-constructor-keys-do-not-match-variable-names)