### PR TITLE
Remove all references of print_statement

### DIFF
--- a/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_python.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_python.mustache
@@ -1,4 +1,4 @@
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import {{{pythonPackageName}}}
 from {{{pythonPackageName}}}.rest import ApiException

--- a/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_python.mustache
+++ b/modules/swagger-codegen/src/main/resources/htmlDocs2/sample_python.mustache
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import time
 import {{{pythonPackageName}}}
 from {{{pythonPackageName}}}.rest import ApiException

--- a/modules/swagger-codegen/src/main/resources/python/api_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_doc.mustache
@@ -19,7 +19,6 @@ Method | HTTP request | Description
 
 ### Example
 ```python
-from __future__ import print_function
 import time
 import {{{packageName}}}
 from {{{packageName}}}.rest import ApiException

--- a/modules/swagger-codegen/src/main/resources/python/api_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_doc.mustache
@@ -19,7 +19,7 @@ Method | HTTP request | Description
 
 ### Example
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import {{{packageName}}}
 from {{{packageName}}}.rest import ApiException

--- a/samples/client/petstore-security-test/python/README.md
+++ b/samples/client/petstore-security-test/python/README.md
@@ -45,7 +45,6 @@ import petstore_api
 Please follow the [installation procedure](#installation--usage) and then run the following:
 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException

--- a/samples/client/petstore-security-test/python/docs/FakeApi.md
+++ b/samples/client/petstore-security-test/python/docs/FakeApi.md
@@ -14,7 +14,7 @@ To test code injection */ ' \" =end -- \\r\\n \\n \\r
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException

--- a/samples/client/petstore-security-test/python/docs/FakeApi.md
+++ b/samples/client/petstore-security-test/python/docs/FakeApi.md
@@ -14,7 +14,6 @@ To test code injection */ ' \" =end -- \\r\\n \\n \\r
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException

--- a/samples/client/petstore/python/README.md
+++ b/samples/client/petstore/python/README.md
@@ -45,7 +45,6 @@ import petstore_api
 Please follow the [installation procedure](#installation--usage) and then run the following:
 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException

--- a/samples/client/petstore/python/docs/FakeApi.md
+++ b/samples/client/petstore/python/docs/FakeApi.md
@@ -18,7 +18,6 @@ To test \"client\" model
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -66,7 +65,6 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -143,7 +141,6 @@ To test enum parameters
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException

--- a/samples/client/petstore/python/docs/FakeApi.md
+++ b/samples/client/petstore/python/docs/FakeApi.md
@@ -18,7 +18,7 @@ To test \"client\" model
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -66,7 +66,7 @@ Fake endpoint for testing various parameters 假端點 偽のエンドポイン�
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -143,7 +143,7 @@ To test enum parameters
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException

--- a/samples/client/petstore/python/docs/PetApi.md
+++ b/samples/client/petstore/python/docs/PetApi.md
@@ -23,7 +23,7 @@ Add a new pet to the store
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -73,7 +73,7 @@ Deletes a pet
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -125,7 +125,7 @@ Multiple status values can be provided with comma separated strings
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -176,7 +176,7 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -227,7 +227,7 @@ Returns a single pet
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -280,7 +280,7 @@ Update an existing pet
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -330,7 +330,7 @@ Updates a pet in the store with form data
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -384,7 +384,7 @@ uploads an image
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException

--- a/samples/client/petstore/python/docs/PetApi.md
+++ b/samples/client/petstore/python/docs/PetApi.md
@@ -23,7 +23,6 @@ Add a new pet to the store
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -73,7 +72,6 @@ Deletes a pet
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -125,7 +123,6 @@ Multiple status values can be provided with comma separated strings
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -176,7 +173,6 @@ Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -227,7 +223,6 @@ Returns a single pet
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -280,7 +275,6 @@ Update an existing pet
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -330,7 +324,6 @@ Updates a pet in the store with form data
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -384,7 +377,6 @@ uploads an image
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException

--- a/samples/client/petstore/python/docs/StoreApi.md
+++ b/samples/client/petstore/python/docs/StoreApi.md
@@ -19,7 +19,7 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -66,7 +66,7 @@ Returns a map of status codes to quantities
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -115,7 +115,7 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -163,7 +163,7 @@ Place an order for a pet
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException

--- a/samples/client/petstore/python/docs/StoreApi.md
+++ b/samples/client/petstore/python/docs/StoreApi.md
@@ -19,7 +19,6 @@ For valid response try integer IDs with value < 1000. Anything above 1000 or non
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -66,7 +65,6 @@ Returns a map of status codes to quantities
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -115,7 +113,6 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -163,7 +160,6 @@ Place an order for a pet
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException

--- a/samples/client/petstore/python/docs/UserApi.md
+++ b/samples/client/petstore/python/docs/UserApi.md
@@ -23,7 +23,7 @@ This can only be done by the logged in user.
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -70,7 +70,7 @@ Creates list of users with given input array
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -117,7 +117,7 @@ Creates list of users with given input array
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -164,7 +164,7 @@ This can only be done by the logged in user.
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -211,7 +211,7 @@ Get user by user name
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -259,7 +259,7 @@ Logs user into the system
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -309,7 +309,7 @@ Logs out current logged in user session
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -352,7 +352,7 @@ This can only be done by the logged in user.
 
 ### Example 
 ```python
-from __future__ import print_statement
+from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException

--- a/samples/client/petstore/python/docs/UserApi.md
+++ b/samples/client/petstore/python/docs/UserApi.md
@@ -23,7 +23,6 @@ This can only be done by the logged in user.
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -70,7 +69,6 @@ Creates list of users with given input array
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -117,7 +115,6 @@ Creates list of users with given input array
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -164,7 +161,6 @@ This can only be done by the logged in user.
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -211,7 +207,6 @@ Get user by user name
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -259,7 +254,6 @@ Logs user into the system
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -309,7 +303,6 @@ Logs out current logged in user session
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException
@@ -352,7 +345,6 @@ This can only be done by the logged in user.
 
 ### Example 
 ```python
-from __future__ import print_function
 import time
 import petstore_api
 from petstore_api.rest import ApiException


### PR DESCRIPTION
[Trello card](https://trello.com/c/o9MfdM3z/8404-doc-various-smooch-python-docs-errors)

Related to #2, removing all the references of `print_statement`.
