### PR TITLE
Fix broken ruby documentation

### DIFF
--- a/TEMPLATE_CHANGES.MD
+++ b/TEMPLATE_CHANGES.MD
@@ -1,7 +1,6 @@
 # Ruby Template Changes
 
 ### modules/swagger-codegen/src/main/resources/ruby/README.mustache
-
 - Removed gem building instructions
 - Removed development gem instructions
 - Removed install from git instructions
@@ -20,6 +19,7 @@
 
 ### modules/swagger-codegen/src/main/resources/ruby/api_doc.mustache
 
+- Fixed a bug where the generated code in the doc didn't generate "," between function parameters properly.
 - Update API KEY instructions to be JWT specific
   - ‘YOUR JWT’
   - Uncomment ‘Bearer’ prefix

--- a/modules/swagger-codegen/src/main/resources/ruby/api_doc.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api_doc.mustache
@@ -11,7 +11,7 @@ Method | HTTP request | Description
 {{#operations}}
 {{#operation}}
 # **{{operationId}}**
-> {{#returnType}}{{returnType}} {{/returnType}}{{operationId}}{{#hasParams}}({{#allParams}}{{#required}}{{{paramName}}}{{#vendorExtensions.x-codegen-hasMoreRequired}}, {{/vendorExtensions.x-codegen-hasMoreRequired}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{{#vendorExtensions.x-codegen-hasRequiredParams}}, {{/vendorExtensions.x-codegen-hasRequiredParams}}opts{{/hasOptionalParams}}){{/hasParams}}
+> {{#returnType}}{{returnType}} {{/returnType}}{{operationId}}({{#allParams}}{{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}})
 
 {{{summary}}}{{#notes}}
 
@@ -49,7 +49,7 @@ opts = { {{#allParams}}{{^required}}
 
 begin
 {{#summary}}  #{{{.}}}
-{{/summary}}  {{#returnType}}result = {{/returnType}}api_instance.{{{operationId}}}{{#hasParams}}({{#allParams}}{{#required}}{{{paramName}}}{{#vendorExtensions.x-codegen-hasMoreRequired}}, {{/vendorExtensions.x-codegen-hasMoreRequired}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{{#vendorExtensions.x-codegen-hasRequiredParams}}, {{/vendorExtensions.x-codegen-hasRequiredParams}}opts{{/hasOptionalParams}}){{/hasParams}}{{#returnType}}
+{{/summary}}  {{#returnType}}result = {{/returnType}}api_instance.{{{operationId}}}({{#allParams}}{{{paramName}}}{{#hasMore}}, {{/hasMore}}{{/allParams}}){{#returnType}}
   p result{{/returnType}}
 rescue {{{moduleName}}}::ApiError => e
   puts "Exception when calling {{classname}}->{{{operationId}}}: #{e}"


### PR DESCRIPTION
[Description of the change](https://trello.com/c/vVHvQEYl/7723-api-wrappers-syntax-error-in-example-documentation)
Fixed wrong generated Ruby code in the doc. Here are a few examples of before/after the fix.

Before
`result = api_instance.update_webhook(app_id, webhook_idwebhook_update_body)`
`result = api_instance.list_webhooks(appId, )`
After
`result = api_instance.update_webhook(app_id, webhook_id, webhook_update_body)`
`result = api_instance.list_webhooks(appId)`