### PR TITLE
Upgraded version of json library to 2.3.1

### DIFF
--- a/TEMPLATE_CHANGES.MD
+++ b/TEMPLATE_CHANGES.MD
@@ -30,6 +30,10 @@
 
 - Fixed JWT auth always taking preference over basic auth even if a JWT was not provided
 
+### modules/swagger-codegen/src/main/resources/ruby/gemspec.mustache
+
+- Updated version of `json` gem used from `1.8.3` to `2.3.1`
+
 # Java Template Changes
 
 ### modules/swagger-codegen/src/main/resources/java/README.mustache

--- a/modules/swagger-codegen/src/main/resources/ruby/gemspec.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/gemspec.mustache
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = "{{{gemRequiredRubyVersion}}}{{^gemRequiredRubyVersion}}>= 1.9{{/gemRequiredRubyVersion}}"
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
-  s.add_runtime_dependency 'json', '~> 1.8', '>= 1.8.3'
+  s.add_runtime_dependency 'json', '~> 2.3', '>= 2.3.1'
 
   s.add_development_dependency 'rspec', '~> 3.4', '>= 3.4.0'
   s.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'


### PR DESCRIPTION
Modified the gemspec mustache template so that the generated ruby library uses a newer version of json. Card: https://zendesk.atlassian.net/jira/software/projects/SCBE/boards/1811?assignee=5d68c1922bab8a0c0a088876&selectedIssue=SCBE-870

After this is merged, the next PR will update the version of the ruby library in the smooch-api-specification repo so that the change propagates to the released gems.

Tested it with the following code:
```ruby
# Load the gem
require 'smooch-api'

# Setup authorization
SmoochApi.configure do |config|
  # Configure HTTP basic authorization (recommended): basicAuth
  config.username = 'user'
  config.password = 'pass'
  config.host = 'https://smooch-alex.ngrok.io'
end

apps_api_instance = SmoochApi::AppApi.new
appuser_api_instance = SmoochApi::AppUserApi.new
message_api_instance = SmoochApi::ConversationApi.new

api_instance = SmoochApi::IntegrationApi.new

opts = { 
    limit: 25, # Integer | The number of records to return.
    offset: 0, # Integer | The number of initial records to skip before picking records to return.
    serviceAccountId: "" # String | The service account ID for which to list apps.
  }
  
appUserPreCreateBody = SmoochApi::AppUserPreCreate.new # AppUserPreCreate | Body for a preCreateAppUser request.
appUserPreCreateBody = {
    userId: 'testUser' + rand(1000).to_s
}
messagePostBody = SmoochApi::MessagePost.new # MessagePost | Body for a postMessage request. Additional arguments are necessary based on message type ([text](https://docs.smooch.io/rest/#text), [image](https://docs.smooch.io/rest/#image), [carousel](https://docs.smooch.io/rest/#carousel), [list](https://docs.smooch.io/rest/#list), [form](https://docs.smooch.io/rest/#form)) 
messagePostBody = {
    role: 'appMaker',
    type: 'text',
    text: 'hello'
}

begin
    # list the apps and get the first one
    result = apps_api_instance.list_apps(opts)
    p result.apps[0]
    appId = result.apps[0].id

    #pre create app user
    result = appuser_api_instance.pre_create_app_user(appId, appUserPreCreateBody)
    p result.appUser.userId
    userId = result.appUser.userId

    #post message
    result = message_api_instance.post_message(appId, userId, messagePostBody)
    p result.message
    messageId = result.message.id

    # get messages
    result = message_api_instance.get_messages(appId, userId)
    p result

rescue SmoochApi::ApiError => e
  puts "Exception when calling IntegrationApi->create_integration: #{e}"
end
```
