### PR TITLE
Expose error response from ruby wrapper

### DIFF
--- a/TEMPLATE_CHANGES.MD
+++ b/TEMPLATE_CHANGES.MD
@@ -1,6 +1,7 @@
 # Ruby Template Changes
 
 ### modules/swagger-codegen/src/main/resources/ruby/README.mustache
+
 - Removed gem building instructions
 - Removed development gem instructions
 - Removed install from git instructions
@@ -33,6 +34,10 @@
 ### modules/swagger-codegen/src/main/resources/ruby/gemspec.mustache
 
 - Updated version of `json` gem used from `1.8.3` to `2.3.1`
+
+### modules/swagger-codegen/src/main/resources/ruby/api_error.mustache
+
+- Added `to_s` function to display error message
 
 # Java Template Changes
 

--- a/modules/swagger-codegen/src/main/resources/ruby/api_error.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api_error.mustache
@@ -26,5 +26,24 @@ module {{moduleName}}
         super arg
       end
     end
+
+    # Override to_s to display a friendly error message
+    def to_s
+      message
+    end
+
+    def message
+      if @message.nil?
+        msg = "Error message: the server returns an error"
+      else
+        msg = @message
+      end
+
+      msg += "\nHTTP status code: #{code}" if code
+      msg += "\nResponse headers: #{response_headers}" if response_headers
+      msg += "\nResponse body: #{response_body}" if response_body
+
+      msg
+    end
   end
 end

--- a/modules/swagger-codegen/src/main/resources/ruby/api_error.mustache
+++ b/modules/swagger-codegen/src/main/resources/ruby/api_error.mustache
@@ -39,10 +39,13 @@ module {{moduleName}}
         msg = @message
       end
 
-      msg += "\nHTTP status code: #{code}" if code
-      msg += "\nResponse headers: #{response_headers}" if response_headers
-      msg += "\nResponse body: #{response_body}" if response_body
+      error_response = {
+        code: code,
+        response_headers: response_headers,
+        response_body: response_body,
+      }
 
+      msg += "\n#{error_response}"
       msg
     end
   end


### PR DESCRIPTION
## RFC 

https://zendesk.atlassian.net/browse/SCBE-966

**Issue**
When using the ruby wrapper, the error wasn't being displayed when outputting the error as a string due to the missing message property.

**Fix** 
This adjusts the swagger api_error.mustache template to append some code that will display the error as a string. 

**Manual tests** 

- [x] Trigger an error using the v1 ruby wrapper: ensure error message is displayed

![image](https://user-images.githubusercontent.com/9314673/112077732-7831ad00-8b53-11eb-9e02-2496b41a0897.png)
